### PR TITLE
feat: add standard ts config and clean up

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
-"use strict"
+'use strict'
 
 module.exports = {
   overrides: [
     {
-      files: ["*.js"],
-      extends: "./js",
+      files: ['*.js'],
+      extends: './js'
     },
     {
-      files: ["*.ts"],
-      extends: "./ts",
-    },
-  ],
+      files: ['*.ts'],
+      extends: './ts'
+    }
+  ]
 }

--- a/js.js
+++ b/js.js
@@ -1,94 +1,87 @@
-"use strict"
+'use strict'
 
 module.exports = {
-  extends: "standard",
+  extends: 'standard',
   parserOptions: {
-    sourceType: "script",
+    sourceType: 'script'
   },
   globals: {
     self: true,
-    mocha: true,
+    mocha: true
   },
   plugins: [
-    "no-only-tests",
-    "jsdoc"
+    'no-only-tests',
+    'jsdoc'
   ],
   rules: {
-    strict: [2, "safe"],
-    curly: "error",
-    "block-scoped-var": 2,
-    complexity: 1,
-    "default-case": 2,
-    "dot-notation": 1,
-    "guard-for-in": 1,
-    "linebreak-style": [1, "unix"],
-    "no-alert": 2,
-    "no-case-declarations": 2,
-    "no-console": 2,
-    "no-constant-condition": 2,
-    "no-continue": 1,
-    "no-div-regex": 2,
-    "no-empty": 1,
-    "no-empty-pattern": 2,
-    "no-extra-semi": 2,
-    "no-implicit-coercion": 2,
-    "no-labels": 2,
-    "no-loop-func": 2,
-    "no-nested-ternary": 1,
-    "no-only-tests/no-only-tests": 2,
-    "no-script-url": 2,
-    "no-warning-comments": 1,
-    "quote-props": [2, "as-needed"],
-    "require-yield": 2,
-    "max-nested-callbacks": [2, 4],
-    "max-depth": [2, 4],
-    "require-await": 2,
-    "jsdoc/check-alignment": 2,
-    "jsdoc/check-examples": 0,
-    "jsdoc/check-indentation": 2,
-    "jsdoc/check-param-names": 2,
-    "jsdoc/check-syntax": 2,
-    "jsdoc/check-tag-names": [2, { definedTags: ["internal", "packageDocumentation"] }],
-    "jsdoc/check-types": 2,
-    "jsdoc/implements-on-classes": 2,
-    "jsdoc/match-description": 0,
-    "jsdoc/newline-after-description": 2,
-    "jsdoc/no-types": 0,
+    strict: ['error', 'safe'],
+    curly: 'error',
+    'block-scoped-var': 'error',
+    complexity: 'warn',
+    'default-case': 'error',
+    'guard-for-in': 'warn',
+    'linebreak-style': ['warn', 'unix'],
+    'no-alert': 'error',
+    'no-console': 'error',
+    'no-continue': 'warn',
+    'no-div-regex': 'error',
+    'no-empty': 'warn',
+    'no-extra-semi': 'error',
+    'no-implicit-coercion': 'error',
+    'no-loop-func': 'error',
+    'no-nested-ternary': 'warn',
+    'no-script-url': 'error',
+    'no-warning-comments': 'warn',
+    'max-nested-callbacks': ['error', 4],
+    'max-depth': ['error', 4],
+    'require-yield': 'error',
+    // plugins
+    'no-only-tests/no-only-tests': 'error',
+    'jsdoc/check-alignment': 'error',
+    'jsdoc/check-examples': 'off',
+    'jsdoc/check-indentation': 'error',
+    'jsdoc/check-param-names': 'error',
+    'jsdoc/check-syntax': 'error',
+    'jsdoc/check-tag-names': ['error', { definedTags: ['internal', 'packageDocumentation'] }],
+    'jsdoc/check-types': 'error',
+    'jsdoc/implements-on-classes': 'error',
+    'jsdoc/match-description': 'off',
+    'jsdoc/newline-after-description': 'error',
+    'jsdoc/no-types': 'off',
     // Note: no-undefined-types rule causes to many false positives:
     // https://github.com/gajus/eslint-plugin-jsdoc/issues/559
     // And it is also unaware of many built in types
     // https://github.com/gajus/eslint-plugin-jsdoc/issues/280
-    "jsdoc/no-undefined-types": 1, 
-    "jsdoc/require-returns-type": 0,
-    "jsdoc/require-description": 0,
-    "jsdoc/require-description-complete-sentence": 0,
-    "jsdoc/require-example": 0,
-    "jsdoc/require-hyphen-before-param-description": 2,
-    "jsdoc/require-jsdoc": 0,
-    "jsdoc/require-param": 2,
-    "jsdoc/require-param-description": 1,
-    "jsdoc/require-param-name": 2,
-    "jsdoc/require-param-type": 2,
+    'jsdoc/no-undefined-types': 'off',
+    'jsdoc/require-returns-type': 'off',
+    'jsdoc/require-description': 'off',
+    'jsdoc/require-description-complete-sentence': 'off',
+    'jsdoc/require-example': 'off',
+    'jsdoc/require-hyphen-before-param-description': 'error',
+    'jsdoc/require-jsdoc': 'off',
+    'jsdoc/require-param': 'error',
+    'jsdoc/require-param-description': 'off',
+    'jsdoc/require-param-name': 'error',
+    'jsdoc/require-param-type': 'error',
     // Note: Do not require @returns because TS often can infer return types and
     // in many such cases it's not worth it.
-    "jsdoc/require-returns": 0,
-    "jsdoc/require-returns-check": 2,
-    "jsdoc/require-returns-description": 1,
-    "jsdoc/require-returns-type": 2,
-     // Note: At the moment type parser used by eslint-plugin-jsdoc does not
-     // parse various forms correctly. For now warn on invalid type froms,
-     // should revisit once following issue is fixed:
-     // https://github.com/jsdoctypeparser/jsdoctypeparser/issues/50
-    "jsdoc/valid-types": 1
+    'jsdoc/require-returns': 'off',
+    'jsdoc/require-returns-check': 'error',
+    'jsdoc/require-returns-description': 'warn',
+    // Note: At the moment type parser used by eslint-plugin-jsdoc does not
+    // parse various forms correctly. For now warn on invalid type froms,
+    // should revisit once following issue is fixed:
+    // https://github.com/jsdoctypeparser/jsdoctypeparser/issues/50
+    'jsdoc/valid-types': 'off'
 
   },
   settings: {
     jsdoc: {
-      mode: "typescript",
+      mode: 'typescript',
       tagNamePreference: {
         augments: {
-          message: "@extends is to be used over @augments as it is more evocative of classes than @augments",
-          replacement: "extends",
+          message: '@extends is to be used over @augments as it is more evocative of classes than @augments',
+          replacement: 'extends'
         }
       },
       structuredTags: {

--- a/js.js
+++ b/js.js
@@ -67,7 +67,7 @@ module.exports = {
     // in many such cases it's not worth it.
     'jsdoc/require-returns': 'off',
     'jsdoc/require-returns-check': 'error',
-    'jsdoc/require-returns-description': 'warn',
+    'jsdoc/require-returns-description': 'off',
     // Note: At the moment type parser used by eslint-plugin-jsdoc does not
     // parse various forms correctly. For now warn on invalid type froms,
     // should revisit once following issue is fixed:

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "eslint-plugin-jsdoc": "^30.4.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^5.0.0"
+    "eslint-plugin-promise": "^4.2.1"
   },
   "peerDependencies": {
     "eslint": ">=6.2.2"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "eslint-plugin-jsdoc": "^30.4.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.2.1"
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^5.0.0"
   },
   "peerDependencies": {
     "eslint": ">=6.2.2"

--- a/package.json
+++ b/package.json
@@ -19,26 +19,31 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.1.0",
     "@typescript-eslint/parser": "^4.1.0",
-    "eslint-config-standard": "^14.1.1",
-    "eslint-plugin-no-only-tests": "^2.4.0",
-    "eslint-plugin-jsdoc": "^30.4.0",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-config-standard-with-typescript": "^19.0.1",
+    "eslint-plugin-etc": "^1.1.7",
     "eslint-plugin-import": "^2.18.0",
-    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-jsdoc": "^30.4.0",
+    "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.0"
+    "eslint-plugin-standard": "^5.0.0"
   },
   "peerDependencies": {
     "eslint": ">=6.2.2"
   },
   "devDependencies": {
-    "typescript": "*",
-    "eslint": "^6.8.0",
-    "tape": "^4.8.0"
+    "eslint": "^7.15.0",
+    "tape": "^5.0.1",
+    "typescript": "*"
   },
   "peerDependenciesMeta": {
     "typescript": {
       "optional": true
     }
+  },
+  "eslintConfig": {
+    "extends": "."
   },
   "repository": {
     "type": "git",

--- a/ts.js
+++ b/ts.js
@@ -1,14 +1,21 @@
-"use strict"
+'use strict'
 
 module.exports = {
-  parser: "@typescript-eslint/parser",
+  parser: '@typescript-eslint/parser',
   parserOptions: {
-    sourceType: "module",
+    sourceType: 'module',
+    project: './tsconfig.json' // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/parser/README.md#parseroptionsproject
   },
-  plugins: ["@typescript-eslint"],
-  extends: ["./js", "plugin:@typescript-eslint/recommended"],
+  extends: [
+    './js',
+    'standard-with-typescript'
+  ],
+  plugins: [
+    'etc'
+  ],
   rules: {
-    // Types often are recursive & no use before define is too restrctive
-    "no-use-before-define": 0
+    'no-use-before-define': 'off', // Types often are recursive & no use before define is too restrctive
+    'etc/prefer-interface': 'error', // https://ncjamieson.com/prefer-interfaces/
+    '@typescript-eslint/prefer-function-type': 'off' // conflicts with 'etc/prefer-interface'
   }
 }


### PR DESCRIPTION
- uses standard-with-typescript for .ts files
- adds eslint-plugin-etc to be able to use `etc/prefer-interface`
    - [https://ncjamieson.com/prefer-interfaces/](https://ncjamieson.com/prefer-interfaces/)
    - more rules from this package can be enabled in the future
- lints repo files
- updates deps
    - standard from 14 to 16 (and deps)
    - eslint from 6 to 7
- removes unchanged rules from standard
    - dot-notation
    - no-case-declarations
    - no-constant-condition
    - no-empty-pattern
    - no-labels
    - quote-props
- removes rule `require-await`
- changes rules `jsdoc/no-undefined-types` from warn to off
- changes rule `jsdoc/require-param-description` from warn to off
- changes rule `jsdoc/valid-types` from warn to off
- change eslint rule values from numbers to 'off', 'warn' and 'error' its just easier to understand

The diff isnt very friendly so i tried to list all the changes made, sorry :/

This should be a breaking change!