### PR TITLE
fix: use eslint env instead of individual globals

### DIFF
--- a/js.js
+++ b/js.js
@@ -5,10 +5,10 @@ module.exports = {
   parserOptions: {
     sourceType: 'script'
   },
-  globals: {
-    self: 'writable',
-    mocha: 'writable',
-    globalThis: 'readonly'
+  env: {
+    es2020: true,
+    browser: true,
+    node: true
   },
   plugins: [
     'no-only-tests',

--- a/js.js
+++ b/js.js
@@ -7,7 +7,8 @@ module.exports = {
   },
   globals: {
     self: true,
-    mocha: true
+    mocha: true,
+    globalThis: false // means it is not writable
   },
   plugins: [
     'no-only-tests',

--- a/js.js
+++ b/js.js
@@ -6,9 +6,9 @@ module.exports = {
     sourceType: 'script'
   },
   globals: {
-    self: true,
-    mocha: true,
-    globalThis: false // means it is not writable
+    self: 'writable',
+    mocha: 'writable',
+    globalThis: 'readonly'
   },
   plugins: [
     'no-only-tests',


### PR DESCRIPTION
Setting the value to `false` means it is not writable