### PR TITLE
feat: detect floating promises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,14 @@ If you do not have `.ts` files in your tree chances are you don't care about typ
 }
 ```
 
+### tsconfig.json
+
+If a `tsconfig.json` is detected in your project, additional rules will be enabled including detection of floating promises.
+
+If these rules are enabled, all linted code must be included in the `"include"` field of your `tsconfig.json` file.
+
+Note that this means you cannot skip including types for your tests if you want to lint them as well.
+
 [node.js ci]: https://github.com/ipfs/eslint-config-ipfs/workflows/Node.js%20CI/badge.svg
 [version.icon]: https://img.shields.io/npm/v/eslint-config-ipfs.svg
 [package.url]: https://npmjs.org/package/eslint-config-ipfs

--- a/js.js
+++ b/js.js
@@ -1,7 +1,13 @@
 'use strict'
 
-module.exports = {
-  extends: 'standard',
+const fs = require('fs')
+const { join } = require('path')
+
+/** @type {Record<string, any>} */
+const config = {
+  extends: [
+    'standard'
+  ],
   parserOptions: {
     sourceType: 'script'
   },
@@ -93,3 +99,20 @@ module.exports = {
     }
   }
 }
+
+const tsconfig = join(process.cwd(), 'tsconfig.json')
+
+if (fs.existsSync(tsconfig)) {
+  config.extends.push('plugin:@typescript-eslint/recommended')
+  config.parserOptions.project = tsconfig
+  config.plugins.push('@typescript-eslint')
+  config.rules = {
+    '@typescript-eslint/no-var-requires': 'warn',
+    '@typescript-eslint/no-empty-function': 'warn',
+    '@typescript-eslint/ban-ts-comment': 'warn',
+    '@typescript-eslint/no-floating-promises': 'error',
+    ...config.rules
+  }
+}
+
+module.exports = config

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,6 +126,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/node": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
+      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "15.0.13",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": ">=6.2.2"
   },
   "devDependencies": {
+    "@types/node": "^16.6.1",
     "eslint": "^7.15.0",
     "tape": "^5.0.1",
     "typescript": "*"

--- a/test/fixtures/valid.js
+++ b/test/fixtures/valid.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const foo = 1
+const bar = function (foo) {
+  return foo + 1
+}
+
+bar(foo)

--- a/test/fixtures/valid.ts
+++ b/test/fixtures/valid.ts
@@ -1,0 +1,8 @@
+
+const foo = 1
+
+export function bar (foo: number): number {
+  return foo + 1
+}
+
+bar(foo)

--- a/test/validate.js
+++ b/test/validate.js
@@ -1,15 +1,33 @@
 const eslint = require("eslint")
 const test = require("tape")
 const eslintrc = require("..")
+const fs = require('fs')
+const path = require('path')
 
-test("load config in eslint to validate all rule syntax is correct", function (t) {
+test("load config in eslint to validate all js rule syntax is correct", function (t) {
   var cli = new eslint.CLIEngine({
     useEslintrc: false,
     baseConfig: eslintrc,
   })
 
-  var code = "var foo = 1\nvar bar = function () {}\nbar(foo)\n"
+  var code = fs.readFileSync(path.join(process.cwd(), 'test/fixtures/valid.js'), {
+    encoding: 'utf-8'
+  })
 
-  t.equal(cli.executeOnText(code).errorCount, 0)
+  t.equal(cli.executeOnText(code, 'index.js').errorCount, 0)
+  t.end()
+})
+
+test("load config in eslint to validate all ts rule syntax is correct", function (t) {
+  var cli = new eslint.CLIEngine({
+    useEslintrc: false,
+    baseConfig: eslintrc,
+  })
+
+  var code = fs.readFileSync(path.join(process.cwd(), 'test/fixtures/valid.ts'), {
+    encoding: 'utf-8'
+  })
+
+  t.equal(cli.executeOnText(code, 'test/fixtures/valid.ts').errorCount, 0)
   t.end()
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    // project options
+    "allowJs": true,
+    "checkJs": true,
+    "target": "ES2019",
+    "lib": [
+      "ES2019",
+      "ES2020.Promise",
+      "ES2020.String",
+      "ES2020.BigInt",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "noEmitOnError": true,
+    "incremental": true,
+    "composite": true,
+    "isolatedModules": true,
+    "removeComments": false,
+    // module resolution
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    // linter checks
+    "noImplicitReturns": false,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    // advanced
+    "importsNotUsedAsValues": "error",
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "stripInternal": true,
+    "resolveJsonModule": true,
+    "outDir": "dist"
+  },
+  "include": [
+    "*.js",
+    "test"
+  ]
+}


### PR DESCRIPTION
The `@typescript-eslint` plugin has an incredibly useful feature that will detect floating promises - that is, promises that are not `await`ed on, returned or otherwise don't have their errors handled.

E.g. it will detect this:

```js
async function foo () {

}

function bar () {
  foo()  // will cause linting to fail
}
```

Possibly contentious, but to enable this, you must be able to derive types from your code, so all linted code must also be type checked.

We've got a few repos that do not have types for their tests which will need backfilling before they can use this feature.

As implemented the `@typescript-eslint/no-floating-promises` rule is enabled when a `tsconfig.json` is detected in a project - this will mean projects that skip typing their tests will break if this is merged.

Harsh, perhaps, but detecting this class of error is incredibly useful.