### PR TITLE
feat: make ts less verbose

### DIFF
--- a/ts.js
+++ b/ts.js
@@ -16,6 +16,9 @@ module.exports = {
   rules: {
     'no-use-before-define': 'off', // Types often are recursive & no use before define is too restrctive
     'etc/prefer-interface': 'error', // https://ncjamieson.com/prefer-interfaces/
-    '@typescript-eslint/prefer-function-type': 'off' // conflicts with 'etc/prefer-interface'
+    '@typescript-eslint/prefer-function-type': 'off', // conflicts with 'etc/prefer-interface'
+    '@typescript-eslint/explicit-function-return-type': 'off', // allow compiler to derive return type
+    'jsdoc/require-param': 'off', // do not require jsdoc for params
+    'jsdoc/require-param-type': 'off' // allow compiler to derive param type
   }
 }


### PR DESCRIPTION
Disable the default rules that require return types and jsdoc `@param`
annotations as the compiler can figure these out.

May need re-enabling if it compromises doc generation.