### PR TITLE
fix: allow self-aliases

### DIFF
--- a/ts.js
+++ b/ts.js
@@ -18,6 +18,7 @@ module.exports = {
     'etc/prefer-interface': 'error', // https://ncjamieson.com/prefer-interfaces/
     '@typescript-eslint/prefer-function-type': 'off', // conflicts with 'etc/prefer-interface'
     '@typescript-eslint/explicit-function-return-type': 'off', // allow compiler to derive return type
+    '@typescript-eslint/no-this-alias': 'off', // allow 'const self = this'
     'jsdoc/require-param': 'off', // do not require jsdoc for params
     'jsdoc/require-param-type': 'off' // allow compiler to derive param type
   }


### PR DESCRIPTION
Allow aliasing self for use within (async) generator functions.

Fixes: #104