### PR TITLE
feat!: require explicit return types

### DIFF
--- a/ts.js
+++ b/ts.js
@@ -17,7 +17,7 @@ module.exports = {
     'no-use-before-define': 'off', // Types often are recursive & no use before define is too restrctive
     'etc/prefer-interface': 'error', // https://ncjamieson.com/prefer-interfaces/
     '@typescript-eslint/prefer-function-type': 'off', // conflicts with 'etc/prefer-interface'
-    '@typescript-eslint/explicit-function-return-type': 'off', // allow compiler to derive return type
+    '@typescript-eslint/explicit-function-return-type': 'error', // functions require return types
     '@typescript-eslint/no-this-alias': 'off', // allow 'const self = this'
     'jsdoc/require-param': 'off', // do not require jsdoc for params
     'jsdoc/require-param-type': 'off' // allow compiler to derive param type


### PR DESCRIPTION
When the compiler can derive return types, it often creates Franken-types of all the properties of a returned type instead of using an interface.

Worse, when it detects an interface it often imports it from a filesystem path instead of an exports map path (e.g. `module/dist/src/foo.js` instead of `module/foo`) which then breaks downstream consumers.

Instead, let's require return types to be explicit to catch these things early.