### PR TITLE
fix: allow stringifying any

### DIFF
--- a/ts.js
+++ b/ts.js
@@ -14,12 +14,13 @@ module.exports = {
     'etc'
   ],
   rules: {
-    'no-use-before-define': 'off', // Types often are recursive & no use before define is too restrctive
+    'no-use-before-define': 'off', // Types often are recursive & no use before define is too restrictive
     'etc/prefer-interface': 'error', // https://ncjamieson.com/prefer-interfaces/
     '@typescript-eslint/prefer-function-type': 'off', // conflicts with 'etc/prefer-interface'
     '@typescript-eslint/explicit-function-return-type': 'error', // functions require return types
     '@typescript-eslint/no-this-alias': 'off', // allow 'const self = this'
     '@typescript-eslint/await-thenable': 'error', // disallows awaiting a value that is not a "Thenable"
+    '@typescript-eslint/restrict-template-expressions': 'off', // allow values with `any` type in template literals
     'jsdoc/require-param': 'off', // do not require jsdoc for params
     'jsdoc/require-param-type': 'off' // allow compiler to derive param type
   }


### PR DESCRIPTION
Sometimes we don't know the type of a thing but it's ok to turn it into a string.