### PR TITLE
fix: allow continue in loops

### DIFF
--- a/js.js
+++ b/js.js
@@ -24,7 +24,6 @@ module.exports = {
     'linebreak-style': ['warn', 'unix'],
     'no-alert': 'error',
     'no-console': 'error',
-    'no-continue': 'warn',
     'no-div-regex': 'error',
     'no-empty': 'warn',
     'no-extra-semi': 'error',


### PR DESCRIPTION
Allow using the `continue` statement in loops.  The warning this generates is usually spurious and often ignored.