### PR TITLE
fix!: only require `await`ing promises returned from inside try/catch blocks

### DIFF
--- a/ts.js
+++ b/ts.js
@@ -21,6 +21,8 @@ module.exports = {
     '@typescript-eslint/no-this-alias': 'off', // allow 'const self = this'
     '@typescript-eslint/await-thenable': 'error', // disallows awaiting a value that is not a "Thenable"
     '@typescript-eslint/restrict-template-expressions': 'off', // allow values with `any` type in template literals
+    'no-return-await': 'off', // disable this rule to use @typescript-eslint/return-await instead
+    '@typescript-eslint/return-await': ['error', 'in-try-catch'], // require awaiting thenables returned from try/catch
     'jsdoc/require-param': 'off', // do not require jsdoc for params
     'jsdoc/require-param-type': 'off' // allow compiler to derive param type
   }


### PR DESCRIPTION
Returning unawaited promises from inside try/catch blocks is usually a bug as the author more than likely intends the catch part to handle errors.

The configuration in this PR disallows `await` before `return` unless it is inside a `try/catch` in which case it is required.

`await` before `return` doesn't cause any harm but I don't think we can configure the rule any other way.

This is a breaking change but one that is fixable with `npm run lint -- --fix`

Fixes: #130

BREAKING CHANGE: `await` is not allowed before `return` unless it is inside a `try/catch` in which case it is required