### PR TITLE
feat!: lint jsx

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,11 @@
 module.exports = {
   overrides: [
     {
-      files: ['*.js'],
+      files: ['*.js', '*.jsx'],
       extends: './js'
     },
     {
-      files: ['*.ts'],
+      files: ['*.ts', '*.tsx'],
       extends: './ts'
     }
   ]


### PR DESCRIPTION
Add `*.jsx` and `*.tsx` to list of files that are linted.

BREAKING CHANGE: previously jsx and tsx files were not linted, now they are