### PR TITLE
chore: restore linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
   },
   "scripts": {
     "clean": "aegir clean",
+    "lint": "aegir lint",
     "dep-check": "aegir dep-check",
     "test": "npm run test:node",
     "test:node": "aegir test -t node",


### PR DESCRIPTION
Requires an aegir update for the build to pass, since aegir depends on this module and the dependency resolution alogrithm results in config that is incompatible with the resolved eslint-plugin-jsdoc dep version.