### PR TITLE
fix: remove import newlines and specify all groups

### DIFF
--- a/src/js.js
+++ b/src/js.js
@@ -81,9 +81,9 @@ module.exports = {
           order: 'asc',
           caseInsensitive: false
         },
-        'newlines-between': 'always',
+        'newlines-between': 'never',
         // the overall order of imports - anything not in this list is grouped together at the end
-        groups: ['builtin', 'external', 'type']
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'object', 'type']
       }
     ]
   },


### PR DESCRIPTION
The import ordering is closer to our internal conventions like this, so this change becomes less disruptive.