### PR TITLE
feat!: add method-signature-style rule

### DIFF
--- a/src/ts.js
+++ b/src/ts.js
@@ -21,6 +21,7 @@ module.exports = {
     '@typescript-eslint/no-this-alias': 'off', // allow 'const self = this'
     '@typescript-eslint/await-thenable': 'error', // disallows awaiting a value that is not a "Thenable"
     '@typescript-eslint/restrict-template-expressions': 'off', // allow values with `any` type in template literals
+    '@typescript-eslint/method-signature-style': ['error', 'method'], // enforce method signature style
     'no-return-await': 'off', // disable this rule to use @typescript-eslint/return-await instead
     '@typescript-eslint/return-await': ['error', 'in-try-catch'], // require awaiting thenables returned from try/catch
     'jsdoc/require-param': 'off', // do not require jsdoc for params


### PR DESCRIPTION
- Enforce this rule https://typescript-eslint.io/rules/method-signature-style#method

This is important for generated docs, which distinguish between methods and properties.  Without this rule, functions on an interface/object can appear as properties rather than methods:

<img width="379" alt="image" src="https://github.com/ipfs/eslint-config-ipfs/assets/665810/d290042f-24d1-441d-9e7a-6e7db20faf4c">

I tested this rule against the js-libp2p monorepo, and using this rule results in API docs that now properly distinguish between methods and properties.

BREAKING CHANGE: All interfaces now need to use method signature style rather than property function style

eg:
before
```ts
interface Foo {
  bar: (baz: number) => void
}
```
after
```ts
interface Foo {
  bar(baz: number): void
}
```
