### PR TITLE
fix: use @typescript-eslint/no-unused-vars

### DIFF
--- a/src/ts.js
+++ b/src/ts.js
@@ -22,6 +22,8 @@ module.exports = {
     '@typescript-eslint/await-thenable': 'error', // disallows awaiting a value that is not a "Thenable"
     '@typescript-eslint/restrict-template-expressions': 'off', // allow values with `any` type in template literals
     '@typescript-eslint/method-signature-style': ['error', 'method'], // enforce method signature style
+    "no-unused-vars": "off", // disable this rule to use @typescript-eslint/no-unused-vars instead
+    "@typescript-eslint/no-unused-vars": "error", // disallow unused variables
     'no-return-await': 'off', // disable this rule to use @typescript-eslint/return-await instead
     '@typescript-eslint/return-await': ['error', 'in-try-catch'], // require awaiting thenables returned from try/catch
     'jsdoc/require-param': 'off', // do not require jsdoc for params

--- a/src/ts.js
+++ b/src/ts.js
@@ -22,8 +22,8 @@ module.exports = {
     '@typescript-eslint/await-thenable': 'error', // disallows awaiting a value that is not a "Thenable"
     '@typescript-eslint/restrict-template-expressions': 'off', // allow values with `any` type in template literals
     '@typescript-eslint/method-signature-style': ['error', 'method'], // enforce method signature style
-    "no-unused-vars": "off", // disable this rule to use @typescript-eslint/no-unused-vars instead
-    "@typescript-eslint/no-unused-vars": "error", // disallow unused variables
+    'no-unused-vars': 'off', // disable this rule to use @typescript-eslint/no-unused-vars instead
+    '@typescript-eslint/no-unused-vars': 'error', // disallow unused variables
     'no-return-await': 'off', // disable this rule to use @typescript-eslint/return-await instead
     '@typescript-eslint/return-await': ['error', 'in-try-catch'], // require awaiting thenables returned from try/catch
     'jsdoc/require-param': 'off', // do not require jsdoc for params


### PR DESCRIPTION
- See https://github.com/ipfs/aegir/issues/1459

Aegir currently relies on typescript to perform two linter rules, which is annoying for reasons mentioned in the above issue.
- `noFallthroughCasesInSwitch`
- `noUnusedLocals`

This PR makes typescript rules more strict to enforce both of these conditions.

For `noFallthroughCasesInSwitch`, it appears that the `standard` eslint rule set [already includes](https://github.com/standard/eslint-config-standard/blob/master/src/index.ts#L143) the [`no-fallthrough`](https://eslint.org/docs/latest/rules/no-fallthrough) rule.
So this PR only needs to enforce `noUnusedLocal`, and we just add [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/).