### PR TITLE
fix: allow `any` args and referencing functions by property name

### DIFF
--- a/src/ts.js
+++ b/src/ts.js
@@ -22,6 +22,8 @@ module.exports = {
     '@typescript-eslint/await-thenable': 'error', // disallows awaiting a value that is not a "Thenable"
     '@typescript-eslint/restrict-template-expressions': 'off', // allow values with `any` type in template literals
     '@typescript-eslint/method-signature-style': ['error', 'method'], // enforce method signature style
+    '@typescript-eslint/no-unsafe-argument': 'off', // allow passing argswith `any` type to functions
+    '@typescript-eslint/unbound-method': 'off', // allow invoking functions that may be unbound (e.g. passed as part of an options object)
     'no-unused-vars': 'off', // disable this rule to use @typescript-eslint/no-unused-vars instead
     '@typescript-eslint/no-unused-vars': 'error', // disallow unused variables
     'no-return-await': 'off', // disable this rule to use @typescript-eslint/return-await instead


### PR DESCRIPTION
Disables two rules:

`@typescript-eslint/no-unsafe-argument` - this prevents passing vars with an `any` type to functions.

Unfortunately we still deal with untyped modules so this will happen.

`@typescript-eslint/unbound-method` - this prevents referencing functions without invoking them.

We need to disable this to do things like pass functions passed as part of an options object on to other functions.