### PR TITLE
fix: pin eslint-plugin-jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-etc": "^2.0.3",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-jsdoc": "^48.2.2",
+    "eslint-plugin-jsdoc": "48.8.3",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1"


### PR DESCRIPTION
The latest `eslint-plugin-jsdoc` broke rule resolution, pin until https://github.com/gajus/eslint-plugin-jsdoc/issues/1277 is fixed.