### PR TITLE
feat!: define rules for consistent type import style

### DIFF
--- a/src/ts.js
+++ b/src/ts.js
@@ -30,6 +30,7 @@ module.exports = {
     '@typescript-eslint/return-await': ['error', 'in-try-catch'], // require awaiting thenables returned from try/catch
     'jsdoc/require-param': 'off', // do not require jsdoc for params
     'jsdoc/require-param-type': 'off', // allow compiler to derive param type
-    'no-undef': 'off' // typescript already checks for undefined variables so this is redundant - https://typescript-eslint.io/troubleshooting/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
+    'no-undef': 'off', // typescript already checks for undefined variables so this is redundant - https://typescript-eslint.io/troubleshooting/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
+    'import/consistent-type-specifier-style': ['error', 'prefer-top-level'] // prefer `import type { Foo }` over `import { type Foo }`
   }
 }


### PR DESCRIPTION
Prefer:

```ts
import type { Foo } from 'bar'
```

over

```ts
import { type Foo } from 'bar'
```

After compilation it doesn't make any difference but it would be good to settle on one style or the other.

BREAKING CHANGE: type import style is now specified, re-run linting with `--fix` to patch up any rule violations